### PR TITLE
Add Permissions to Rust.yml (closes #39)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,7 @@
 name: Rust
-
+permissions:
+  contents: read # Globally allow reading the repository contents
+  
 on: [push, pull_request]
 
 env:


### PR DESCRIPTION
I decided to give read permission to our repo for all jobs within the workflow since that's all our current jobs need for now and read permissions are very weak overall so i think that the maintainability advantages are worth it (More permissions can be added to individual jobs later on)

This is the permission we're handing out now:
(Work with the contents of the repository. For example, contents: read permits an action to list the commits)